### PR TITLE
Associate optlist_overrides DataConfig with User

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -64,6 +64,8 @@ class SessionsController < ApplicationController
   end
 
   def update_user_if_needed(user)
+    opt_overrides = DataConfig.optlist_overrides(user)
+    user.update(data_config_id: opt_overrides.first.id) unless opt_overrides.empty?
     user.update(password: session_params[:password]) if user.password != session_params[:password]
   end
 

--- a/db/migrate/20250410184116_add_data_config_ref_to_users.rb
+++ b/db/migrate/20250410184116_add_data_config_ref_to_users.rb
@@ -1,0 +1,5 @@
+class AddDataConfigRefToUsers < ActiveRecord::Migration[8.0]
+  def change
+    add_reference :users, :data_config, null: true, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_03_08_192715) do
+ActiveRecord::Schema[8.0].define(version: 2025_04_10_184116) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -108,6 +108,8 @@ ActiveRecord::Schema[8.0].define(version: 2025_03_08_192715) do
     t.string "cspace_api_version", null: false
     t.string "cspace_profile", null: false
     t.string "cspace_ui_version", null: false
+    t.integer "data_config_id"
+    t.index ["data_config_id"], name: "index_users_on_data_config_id"
     t.index ["email_address", "cspace_url"], name: "index_users_on_email_address_and_cspace_url", unique: true
   end
 
@@ -119,4 +121,5 @@ ActiveRecord::Schema[8.0].define(version: 2025_03_08_192715) do
   add_foreign_key "data_items", "tasks", column: "current_task_id"
   add_foreign_key "sessions", "users"
   add_foreign_key "tasks", "activities"
+  add_foreign_key "users", "data_configs"
 end

--- a/test/controllers/sessions_controller_test.rb
+++ b/test/controllers/sessions_controller_test.rb
@@ -58,12 +58,35 @@ class SessionsControllerTest < ActionDispatch::IntegrationTest
     assert_equal "Failed to access version information from CollectionSpace.", flash[:alert]
   end
 
+  test "associates optlist_overrides DataConfig with User" do
+    oo = create_data_config_optlist_overrides({profile: "tenantname"})
+    user = users(:hostedtenantuser)
+    @client = setup_mock_tenant_client
+    setup_successful_auth
+    post session_url, params: auth_params(user)
+    user.reload
+
+    assert_equal oo.id, user.data_config_id
+  end
+
   private
 
   def setup_mock_client
     client = CollectionSpace::Client.new(
       CollectionSpace::Configuration.new(
         base_uri: "https://core.dev.collectionspace.org/cspace-services",
+        username: "admin@core.collectionspace.org",
+        password: "Administrator"
+      )
+    )
+    CollectionSpaceApi.stubs(:client_for).returns(client)
+    client
+  end
+
+  def setup_mock_tenant_client
+    client = CollectionSpace::Client.new(
+      CollectionSpace::Configuration.new(
+        base_uri: "https://tenantname.collectionspace.org/cspace-services",
         username: "admin@core.collectionspace.org",
         password: "Administrator"
       )

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -7,6 +7,7 @@ admin:
   cspace_url: https://core.dev.collectionspace.org/cspace-services
   email_address: admin@collectionspace.org
   password: Administrator
+  data_config_id: nil
 
 reader:
   cspace_api_version: "1.0.0"
@@ -15,3 +16,13 @@ reader:
   cspace_url: https://core.dev.collectionspace.org/cspace-services
   email_address: reader@collectionspace.org
   password: dear_reader
+  data_config_id: nil
+
+hostedtenantuser:
+  cspace_api_version: "1.0.0"
+  cspace_profile: "core"
+  cspace_ui_version: "1.0.0"
+  cspace_url: https://tenantname.collectionspace.org/cspace-services
+  email_address: user@tenantname.collectionspace.org
+  password: apassword
+  data_config_id: nil

--- a/test/models/data_config_test.rb
+++ b/test/models/data_config_test.rb
@@ -20,7 +20,7 @@ class DataConfigTest < ActiveSupport::TestCase
 
     @optlist_config = DataConfig.new(
       config_type: "optlist_overrides",
-      profile: "core",
+      profile: "tenantname",
       url: "https://example.com/core-optlist.json"
     )
   end
@@ -93,8 +93,8 @@ class DataConfigTest < ActiveSupport::TestCase
   # Scope Tests
   test "optlist_overrides scope" do
     @optlist_config.save!
-    assert_includes DataConfig.optlist_overrides(users(:admin)), @optlist_config
-    assert_not_includes DataConfig.optlist_overrides(users(:admin)), @record_type_config
+    assert_includes DataConfig.optlist_overrides(users(:hostedtenantuser)), @optlist_config
+    assert_not_includes DataConfig.optlist_overrides(users(:hostedtenantuser)), @record_type_config
   end
 
   test "record_type scope" do

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -80,6 +80,13 @@ class UserTest < ActiveSupport::TestCase
     assert_includes user.errors[:password], "is too short (minimum is 8 characters)"
   end
 
+  test "can create without optlist_overrides DataConfig" do
+    user = User.create!(valid_user_attributes)
+    Session.create!(user: user)
+
+    assert_nil user.data_config_id
+  end
+
   test "destroying user destroys associated sessions" do
     user = User.create!(valid_user_attributes)
     Session.create!(user: user)


### PR DESCRIPTION
RE: #36 

Since User is associated with one CollectionSpace instance
and
optlist_overrides DataConfig.profile is intended to be matched against User.cspace_url...

I thought maybe it makes more sense to put this DataConfig on the User. 

Rough sketch in this PR as a starting place for discussion that isn't completely abstract. I'm sure I put 87% of the changes in a non-ideal place. 

I'm not really sure the optlist_overrides DataConfig.id even needs to be persisted on the User. The DataConfig's JSON just needs to be passed to collectionspace-mapper at the beginning of Activities including OptList::AllowOverride

Also not sure a DataConfig scope for optlist_overrides is needed since there is only ever supposed to be one optlist_overrides DataConfig per "profile" (which is tenant name (or the domain for that tenant; e.g. "ohiohistory" for ohc tenant)
