### PR TITLE
Trigger activity refresh when task completed

### DIFF
--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -22,6 +22,8 @@ class Activity < ApplicationRecord
     end
   end
 
+  broadcasts_refreshes
+
   def boolean_attributes
     BatchConfig.boolean_attributes
   end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -2,7 +2,7 @@ class Task < ApplicationRecord
   include ActionView::RecordIdentifier
   include TransitionsStatus
 
-  belongs_to :activity
+  belongs_to :activity, touch: true
   delegate :user, to: :activity
   has_many :data_items, through: :activity
   has_many_attached :files

--- a/app/views/activities/_activity.html.erb
+++ b/app/views/activities/_activity.html.erb
@@ -1,3 +1,4 @@
+<%= turbo_stream_from activity %>
 <%= tag.div id: dom_id(activity), class: "card mb-3" do %>
   <div class="card-header d-flex justify-content-between">
     <div><%= file_names(activity) %></div>
@@ -41,7 +42,16 @@
           <div class="d-flex align-items-center mb-1">
             <span class="text-muted small me-2">Workflow Task</span>
           </div>
-          <span class="text-monospace fw-medium"><%= task_name(activity) %></span>
+          <div class="d-flex align-items-center">
+            <% if activity.current_task %>
+              <span class="text-monospace fw-medium me-2"><%= task_name(activity) %></span>
+              <span class="badge bg-<%= task_status_color(activity.current_task.status) %>">
+                <%= activity.current_task.status %>
+              </span>
+            <% else %>
+              <span class="text-monospace fw-medium">No task is active</span>
+            <% end %>
+          </div>
         </div>
 
         <div class="mb-3">

--- a/app/views/activities/show.html.erb
+++ b/app/views/activities/show.html.erb
@@ -1,6 +1,7 @@
+<%= turbo_stream_from @activity%>
 <%= turbo_stream_from @activity, :tasks %>
 
-<div class="card mb-4">
+<div id="<%= dom_id(@activity) %>" class="card mb-4">
   <div class="card-header d-flex justify-content-between align-items-center">
     <h5 class="mb-0"><%= @activity.class.display_name %></h5>
     <div>

--- a/app/views/tasks/_feedback.html.erb
+++ b/app/views/tasks/_feedback.html.erb
@@ -1,0 +1,25 @@
+<div class="card mb-4">
+  <div class="card-header d-flex justify-content-between align-items-center">
+    <h5 class="mb-0">Feedback</h5>
+  </div>
+
+  <% feedback.each do |category, entries| %>
+    <% if entries.any? %>
+      <div class="card-body">
+        <div class="mb-4">
+          <h6 class="text-muted fw-semibold border-bottom pb-2 mb-3"><%= category.titleize %></h6>
+          <ul>
+            <% entries.each do |subcategory, messages| %>
+              <li><%= subcategory.titleize %></li>
+              <ul>
+                <% messages.each do |message| %>
+                  <%= content_tag :li, message %>
+                <% end %>
+              </ul>
+            <% end %>
+          </ul>
+        </div>
+      </div>
+    <% end %>
+  <% end %>
+</div>

--- a/app/views/tasks/show.html.erb
+++ b/app/views/tasks/show.html.erb
@@ -1,6 +1,6 @@
 <%= turbo_stream_from @task %>
 
-<div class="card">
+<div class="card mb-4">
   <div class="card-header d-flex justify-content-between align-items-center">
     <h5 class="mb-0"><%= @task.class.display_name %></h5>
     <div>
@@ -12,3 +12,7 @@
     <%= render "details", task: @task %>
   </div>
 </div>
+
+<% if @task.feedback.present? %>
+  <%= render "feedback", feedback: @task.feedback %>
+<% end %>


### PR DESCRIPTION
This makes it so the state of all workflow tasks is in sync post
task completion.

Also provided minimal task feedback rendering so can display
things like missing field errors.

Also display status of activity (current task) on dashboard.

Resolves #83
