### PR TITLE
data toolkit 112

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -43,10 +43,16 @@ module ApplicationHelper
       "warning"
     when :succeeded
       "success"
+    when :review
+      "warning"
     when :failed
       "danger"
     else
       "primary"
     end
+  end
+
+  def task_status_text(status)
+    t("tasks.status.#{status}")
   end
 end

--- a/app/jobs/generic_task_finalizer_job.rb
+++ b/app/jobs/generic_task_finalizer_job.rb
@@ -23,11 +23,17 @@ class GenericTaskFinalizerJob < ApplicationJob
 
   def item_feedback_for(feedback, items)
     items.find_each(batch_size: 500) do |item|
-      item.feedback_for.errors.each do |err|
-        feedback.add_to_errors(subtype: err.subtype, details: err.details)
+      item_feedback = item.feedback_for
+      next unless item_feedback.displayable?
+
+      item_feedback.errors.each do |e|
+        feedback.add_to_errors(subtype: e.subtype, details: e.details)
       end
-      item.feedback_for.warnings.each do |err|
-        feedback.add_to_warnings(subtype: err.subtype, details: err.details)
+      item_feedback.warnings.each do |w|
+        feedback.add_to_warnings(subtype: w.subtype, details: w.details)
+      end
+      item_feedback.messages.each do |m|
+        feedback.add_to_messages(subtype: m.subtype, details: m.details)
       end
     end
     feedback

--- a/app/models/concerns/transitions_status.rb
+++ b/app/models/concerns/transitions_status.rb
@@ -2,11 +2,11 @@ module TransitionsStatus
   extend ActiveSupport::Concern
 
   # Statuses that indicate completion (success, failure, or requiring review)
-  PROGRESSED_STATUSES = %w[failed review succeeded].freeze
+  COMPLETION_STATUSES = %w[failed review succeeded].freeze
 
   included do
     def completed?
-      PROGRESSED_STATUSES.include?(status)
+      COMPLETION_STATUSES.include?(status)
     end
 
     def fail!(feedback = nil)

--- a/app/models/concerns/transitions_status.rb
+++ b/app/models/concerns/transitions_status.rb
@@ -17,8 +17,9 @@ module TransitionsStatus
       update!(status: "succeeded", completed_at: Time.current)
     end
 
-    def suspend!
-      update!(status: "review", completed_at: Time.current)
+    def suspend!(feedback = nil)
+      params = {status: "review", completed_at: Time.current, feedback: feedback}.compact
+      update!(**params)
     end
   end
 end

--- a/app/models/concerns/transitions_status.rb
+++ b/app/models/concerns/transitions_status.rb
@@ -16,5 +16,9 @@ module TransitionsStatus
     def success!
       update!(status: "succeeded", completed_at: Time.current)
     end
+
+    def suspend!
+      update!(status: "review", completed_at: Time.current)
+    end
   end
 end

--- a/app/models/concerns/transitions_status.rb
+++ b/app/models/concerns/transitions_status.rb
@@ -1,6 +1,9 @@
 module TransitionsStatus
   extend ActiveSupport::Concern
 
+  # Statuses that indicate completion (success, failure, or requiring review)
+  PROGRESSED_STATUSES = %w[failed review succeeded].freeze
+
   included do
     def fail!(feedback = nil)
       params = {status: "failed", completed_at: Time.current, feedback: feedback}.compact

--- a/app/models/concerns/transitions_status.rb
+++ b/app/models/concerns/transitions_status.rb
@@ -5,6 +5,10 @@ module TransitionsStatus
   PROGRESSED_STATUSES = %w[failed review succeeded].freeze
 
   included do
+    def completed?
+      PROGRESSED_STATUSES.include?(status)
+    end
+
     def fail!(feedback = nil)
       params = {status: "failed", completed_at: Time.current, feedback: feedback}.compact
       update!(**params)

--- a/app/models/data_item.rb
+++ b/app/models/data_item.rb
@@ -6,7 +6,11 @@ class DataItem < ApplicationRecord
   belongs_to :current_task, class_name: "Task"
 
   enum :status, {
-    pending: "pending", running: "running", succeeded: "succeeded", failed: "failed"
+    pending: "pending",
+    running: "running",
+    succeeded: "succeeded",
+    review: "review",
+    failed: "failed"
   }, default: :pending
 
   validates :data, presence: true

--- a/app/models/data_item.rb
+++ b/app/models/data_item.rb
@@ -18,7 +18,7 @@ class DataItem < ApplicationRecord
   validates :position, uniqueness: {scope: :activity_id}
 
   after_update_commit do
-    next unless PROGRESSED_STATUSES.include?(status)
+    next unless completed?
 
     next current_task.update_progress if current_task.progress >= 100
     current_task.touch if rand < 0.1 # bumps task.updated_at

--- a/app/models/data_item.rb
+++ b/app/models/data_item.rb
@@ -18,7 +18,7 @@ class DataItem < ApplicationRecord
   validates :position, uniqueness: {scope: :activity_id}
 
   after_update_commit do
-    next unless Task::PROGRESSED_STATUSES.include?(status)
+    next unless PROGRESSED_STATUSES.include?(status)
 
     next current_task.update_progress if current_task.progress >= 100
     current_task.touch if rand < 0.1 # bumps task.updated_at

--- a/app/models/data_item.rb
+++ b/app/models/data_item.rb
@@ -18,7 +18,7 @@ class DataItem < ApplicationRecord
   validates :position, uniqueness: {scope: :activity_id}
 
   after_update_commit do
-    next unless succeeded? || failed? || review?
+    next unless Task::PROGRESSED_STATUSES.include?(status)
 
     next current_task.update_progress if current_task.progress >= 100
     current_task.touch if rand < 0.1 # bumps task.updated_at

--- a/app/models/data_item.rb
+++ b/app/models/data_item.rb
@@ -18,7 +18,7 @@ class DataItem < ApplicationRecord
   validates :position, uniqueness: {scope: :activity_id}
 
   after_update_commit do
-    next unless succeeded? || failed?
+    next unless succeeded? || failed? || review?
 
     next current_task.update_progress if current_task.progress >= 100
     current_task.touch if rand < 0.1 # bumps task.updated_at

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -48,7 +48,7 @@ class Task < ApplicationRecord
     case status
     when "pending", "queued" then 0
     when "running" then calculate_progress
-    when "succeeded", "failed", "review" then 100
+    when *PROGRESSED_STATUSES then 100
     else 0
     end
   end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -47,7 +47,7 @@ class Task < ApplicationRecord
     case status
     when "pending", "queued" then 0
     when "running" then calculate_progress
-    when *PROGRESSED_STATUSES then 100
+    when *COMPLETION_STATUSES then 100
     else 0
     end
   end
@@ -93,7 +93,7 @@ class Task < ApplicationRecord
   def calculate_progress
     return 0 if data_items.empty?
 
-    completed_items_ratio = data_items.where(status: [PROGRESSED_STATUSES]).count.to_f / data_items.count
+    completed_items_ratio = data_items.where(status: COMPLETION_STATUSES).count.to_f / data_items.count
     (completed_items_ratio * 100).round(2)
   end
 
@@ -112,7 +112,7 @@ class Task < ApplicationRecord
       # only run finalizer on first transitioning to a completed status
       # not when, for example, going from review -> succeeded
       previous_status = saved_change_to_status.first
-      unless PROGRESSED_STATUSES.include?(previous_status)
+      unless COMPLETION_STATUSES.include?(previous_status)
         finalizer&.perform_later(self)
       end
     end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -48,7 +48,7 @@ class Task < ApplicationRecord
     case status
     when "pending", "queued" then 0
     when "running" then calculate_progress
-    when "succeeded", "failed" then 100
+    when "succeeded", "failed", "review" then 100
     else 0
     end
   end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -17,8 +17,6 @@ class Task < ApplicationRecord
     failed: "failed"
   }, default: :pending
 
-  PROGRESSED_STATUSES = %w[failed review succeeded].freeze
-
   validates :type, :status, presence: true
 
   after_update_commit :broadcast_updates

--- a/app/models/tasks/pre_check_ingest_data.rb
+++ b/app/models/tasks/pre_check_ingest_data.rb
@@ -5,7 +5,7 @@ module Tasks
       [Tasks::ProcessUploadedFiles]
     end
 
-    def finalizer = PreCheckIngestDataFinalizerJob
+    def finalizer = GenericTaskFinalizerJob
 
     def handler = PreCheckIngestDataJob
 

--- a/app/views/activities/_activity.html.erb
+++ b/app/views/activities/_activity.html.erb
@@ -46,7 +46,7 @@
             <% if activity.current_task %>
               <span class="text-monospace fw-medium me-2"><%= task_name(activity) %></span>
               <span class="badge bg-<%= task_status_color(activity.current_task.status) %>">
-                <%= activity.current_task.status %>
+                <%= task_status_text(activity.current_task.status) %>
               </span>
             <% else %>
               <span class="text-monospace fw-medium">No task is active</span>

--- a/app/views/tasks/_details.html.erb
+++ b/app/views/tasks/_details.html.erb
@@ -3,7 +3,7 @@
     <div class="col-sm-3 fw-bold">Status:</div>
     <div class="col-sm-9">
       <span class="badge bg-<%= task_status_color(task.status) %>">
-        <%= task.status.titleize %>
+        <%= task_status_text(task.status) %>
       </span>
     </div>
   </div>

--- a/app/views/tasks/_task.html.erb
+++ b/app/views/tasks/_task.html.erb
@@ -2,7 +2,7 @@
   <td><%= task.class.display_name %></td>
   <td>
     <span class="badge bg-<%= task_status_color(task.status) %>">
-      <%= task.status.titleize %>
+      <%= task_status_text(task.status) %>
     </span>
   </td>
   <td><%= local_time(task.created_at) %></td>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -103,3 +103,10 @@ en:
           csvlint_inconsistent_values: >-
             Inconsistent Values: You may wish to double check the values in
             %{details}
+    status:
+      failed: Failed
+      pending: Pending
+      queued: Queued
+      review: Review
+      running: Running
+      succeeded: Succeeded

--- a/test/jobs/generic_task_finalizer_job_test.rb
+++ b/test/jobs/generic_task_finalizer_job_test.rb
@@ -1,7 +1,7 @@
 require "ostruct"
 require "test_helper"
 
-class PreCheckIngestDataFinalizerJobTest < ActiveJob::TestCase
+class GenericTaskFinalizerJobTest < ActiveJob::TestCase
   test "fails task and adds error to feedback if any item jobs failed" do
     successful_first_item_check
     set_up_and_run_task
@@ -9,7 +9,7 @@ class PreCheckIngestDataFinalizerJobTest < ActiveJob::TestCase
     # the task will have succeeded, so let's reset it to a failed state
     fail_task(task: @task, indexes: [3, 5])
 
-    assert_performed_with(job: PreCheckIngestDataFinalizerJob, args: [@task]) do
+    assert_performed_with(job: GenericTaskFinalizerJob, args: [@task]) do
       perform_enqueued_jobs
     end
 
@@ -61,7 +61,7 @@ class PreCheckIngestDataFinalizerJobTest < ActiveJob::TestCase
     @task = @activity.next_task
     @task.run
     assert_performed_with(job: PreCheckIngestDataJob, args: [@task]) do
-      assert_performed_with(job: PreCheckIngestDataFinalizerJob, args: [@task]) do
+      assert_performed_with(job: GenericTaskFinalizerJob, args: [@task]) do
         perform_enqueued_jobs
       end
     end

--- a/test/models/data_item_test.rb
+++ b/test/models/data_item_test.rb
@@ -48,4 +48,23 @@ class DataItemTest < ActiveSupport::TestCase
     assert_equal "review", @data_item.status
     assert_not_nil @data_item.completed_at
   end
+
+  test "should execute suspend! method correctly when feedback is valid feedback Hash" do
+    feedback_hash = {"parent" => "Tasks::PreCheckIngestData",
+                     "errors" => [],
+                     "warnings" =>
+     [{"type" => "warning",
+       "subtype" => "unknown_field",
+       "details" => "objectNumber is an unknown field",
+       "prefix" => "data_item"}],
+                     "messages" => []}
+
+    @data_item.save!
+    @data_item.suspend!(feedback_hash)
+
+    assert_equal "review", @data_item.status
+    assert_not_nil @data_item.completed_at
+    feedback = @data_item.feedback_for
+    assert feedback.ok?
+  end
 end

--- a/test/models/data_item_test.rb
+++ b/test/models/data_item_test.rb
@@ -40,4 +40,12 @@ class DataItemTest < ActiveSupport::TestCase
     refute duplicate_item.valid?
     assert_includes duplicate_item.errors[:position], "has already been taken"
   end
+
+  test "should execute suspend! method correctly" do
+    @data_item.save!
+    @data_item.suspend!
+
+    assert_equal "review", @data_item.status
+    assert_not_nil @data_item.completed_at
+  end
 end

--- a/test/models/task_test.rb
+++ b/test/models/task_test.rb
@@ -77,7 +77,7 @@ class TaskTest < ActiveSupport::TestCase
         type: "Activities::CreateOrUpdateRecords",
         config: {action: "create"},
         data_config: create_data_config_record_type({record_type: "acquisitions"}),
-        files: create_uploaded_files(["test.csv"]),
+        files: create_uploaded_files(["test.csv"])
       }
     )
     first_task = activity.tasks[0]

--- a/test/models/task_test.rb
+++ b/test/models/task_test.rb
@@ -36,9 +36,7 @@ class TaskTest < ActiveSupport::TestCase
   end
 
   test "should allow valid status values" do
-    valid_statuses = [:pending, :queued, :running, :succeeded, :review, :failed]
-
-    valid_statuses.each do |status|
+    Task.statuses.keys.each do |status|
       @task.status = status
       assert @task.valid?, "#{status} should be a valid status"
     end


### PR DESCRIPTION
This PR adds a review status to the task and data item models.

When processing a task or data items jobs should call one of:

- success! (all good -- sets status to succeeded)
- suspend!(feedback) (warnings -- sets status to review)
- fail!(feedback) (error -- sets status to failed, workflow must not continue)

When a task is determined to be in a review (or "suspended" state), either by setting the status directly or by data item processing the workflow becomes soft-locked. To continue with a workflow, a user will have to "unlock" the task (which behind the scenes will update status to succeeded), and will prevent automatic transitions (https://github.com/dts-hosting/data-toolkit/issues/104). This "unlock" feature is not yet implemented and is not part of this pull request.

Opportunistically, this PR includes an update to the one currently implemented finalizer job. For now at least, it looks like this finalizer could work for different types of tasks. That may not survive in the real world, but for now at least it looks possible to start generic, then create new, more specific finalizers as needed.