### PR TITLE
Don't set feedback during start!

### DIFF
--- a/app/models/concerns/transitions_status.rb
+++ b/app/models/concerns/transitions_status.rb
@@ -15,9 +15,7 @@ module TransitionsStatus
     end
 
     def start!
-      update!(status: "running",
-        started_at: Time.current,
-        feedback: Feedback.new(feedback_context))
+      update!(status: "running", started_at: Time.current)
     end
 
     def success!


### PR DESCRIPTION
This does 2 things:

1. Writes less, if feedback is needed it gets set later.
2. Makes it easier to query tasks or items w/o feedback (nil).

Resolves #119
