### PR TITLE
Manifest registry updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ PASSWORD=Administrator
 
 # import data configs from a manifest registry
 MR_URL=https://gist.githubusercontent.com/mark-cooper/e8c7a5469ee9e365dc3265068726ed94/raw/8d1384a9172f508c326508aa86c97fa24acf4f21/meta-manifest.json
-./bin/rake crud:import:manifest_registry[$MR_URL]
+./bin/rake "crud:import:manifest_registry[$MR_URL]"
 
 # create an activity
 USER_ID=1

--- a/app/controllers/manifest_registries_controller.rb
+++ b/app/controllers/manifest_registries_controller.rb
@@ -23,6 +23,8 @@ class ManifestRegistriesController < AdminController
   def destroy
     @manifest_registry.destroy
     redirect_to manifest_registries_path, notice: "Manifest registry was successfully deleted."
+  rescue ActiveRecord::InvalidForeignKey
+    redirect_to manifest_registries_path, alert: "Cannot delete manifest registry because it contains data configs that are currently in use."
   end
 
   def run

--- a/app/models/data_config.rb
+++ b/app/models/data_config.rb
@@ -2,6 +2,7 @@ class DataConfig < ApplicationRecord
   ALLOWED_CONFIG_TYPES = %i[optlist_overrides record_type term_lists].freeze
 
   include RequiresUrl
+  has_many :activities, dependent: :restrict_with_exception
   belongs_to :manifest, counter_cache: true
 
   validates :config_type, presence: true,

--- a/app/models/manifest.rb
+++ b/app/models/manifest.rb
@@ -26,6 +26,11 @@ class Manifest < ApplicationRecord
         record_type: entry["type"]
       }
       data_config = DataConfig.find_or_create_by(opts)
+      unless data_config.valid?
+        Rails.logger.debug { "Data config could not be imported: #{data_config.errors.full_messages.join(";")}" }
+        next
+      end
+
       data_config.update(url: url) if url != data_config.url
       yield data_config if block_given?
     end

--- a/app/views/manifest_registries/_manifest_registry.html.erb
+++ b/app/views/manifest_registries/_manifest_registry.html.erb
@@ -10,6 +10,7 @@
                     manifest_registry_path(manifest_registry),
                     method: :delete,
                     class: "btn btn-sm btn-outline-danger",
+                    disabled: !manifest_registry.safe_to_delete?,
                     form: { data: { turbo_confirm: "Are you sure you want to delete this registry?" } } %>
     </div>
   </div>

--- a/test/models/manifest_registry_test.rb
+++ b/test/models/manifest_registry_test.rb
@@ -1,0 +1,23 @@
+require "test_helper"
+
+class ManifestRegistryTest < ActiveSupport::TestCase
+  def setup
+    @manifest_registry = ManifestRegistry.create!(
+      url: "https://example.com/registry.json"
+    )
+  end
+
+  test "safe_to_delete? returns true when no manifests or data configs" do
+    @manifest_registry.manifests.create!(url: "https://example.com/test-manifest")
+
+    assert @manifest_registry.safe_to_delete?
+  end
+
+  test "safe_to_delete? returns false when manifests or data configs exist" do
+    @manifest_registry.manifests.create!(url: "https://example.com/test-manifest")
+    data_config = create_data_config_record_type(manifest: @manifest_registry.manifests.first)
+    create_activity(data_config: data_config)
+
+    assert_not @manifest_registry.safe_to_delete?
+  end
+end


### PR DESCRIPTION
Prevent deletion when there are data configs in use.
Check manifest and data config validity during import.
