### PR TITLE
Re-org the activity requires methods

### DIFF
--- a/app/controllers/activities_controller.rb
+++ b/app/controllers/activities_controller.rb
@@ -4,7 +4,7 @@ class ActivitiesController < ApplicationController
 
   def new
     @activity = @activity_type.new
-    @activity.build_batch_config if @activity.requires_batch_config?
+    @activity.build_batch_config if @activity.class.has_batch_config?
   end
 
   def create

--- a/app/jobs/process_uploaded_files_job.rb
+++ b/app/jobs/process_uploaded_files_job.rb
@@ -8,6 +8,10 @@ class ProcessUploadedFilesJob < ApplicationJob
     task.start!
     Rails.logger.info "File upload job started"
 
+    if task.activity.files.empty? && !task.activity.class.requires_files?
+      task.success! && return
+    end
+
     feedback = task.feedback_for
 
     if task.activity.files.empty?
@@ -24,7 +28,6 @@ class ProcessUploadedFilesJob < ApplicationJob
 
     validated.data.each { |table| import_from_csv(task, table) }
 
-    # Can update status directly as it's not spawning other jobs
     task.success!
   rescue => e
     Rails.logger.error "#{e.message} -- #{e.backtrace.first(5)}"

--- a/app/models/activities/check_media_derivatives.rb
+++ b/app/models/activities/check_media_derivatives.rb
@@ -1,24 +1,8 @@
 module Activities
   class CheckMediaDerivatives < Activity
-    # Takes 0 to many files. Runs on all site media of record_type if no file given
+    validates :files, presence: true, length: {minimum: 1, message: "must have at least one file"}
 
     def data_config_type = "media_record_type"
-
-    def requires_batch_config?
-      false
-    end
-
-    def requires_config_fields?
-      false
-    end
-
-    def requires_files?
-      true
-    end
-
-    def requires_single_file?
-      false
-    end
 
     def workflow
       [Tasks::ProcessUploadedFiles]
@@ -26,6 +10,18 @@ module Activities
 
     def self.display_name
       "Check Media Derivatives"
+    end
+
+    def self.file_requirement
+      :required_multiple
+    end
+
+    def self.has_batch_config?
+      false
+    end
+
+    def self.has_config_fields?
+      false
     end
   end
 end

--- a/app/models/activities/create_or_update_records.rb
+++ b/app/models/activities/create_or_update_records.rb
@@ -8,22 +8,6 @@ module Activities
     def data_handler = @data_handler ||=
                          CollectionSpaceMapper.single_record_type_handler_for(self)
 
-    def requires_batch_config?
-      true
-    end
-
-    def requires_config_fields?
-      true
-    end
-
-    def requires_files?
-      true
-    end
-
-    def requires_single_file?
-      true
-    end
-
     def workflow
       # Tasks::ProcessUploadedFiles, Tasks::PreCheckIngestData,
       #   Tasks::ProcessTask, Tasks::TransferTask
@@ -32,6 +16,18 @@ module Activities
 
     def self.display_name
       "Create or Update Records"
+    end
+
+    def self.file_requirement
+      :required_single
+    end
+
+    def self.has_batch_config?
+      true
+    end
+
+    def self.has_config_fields?
+      true
     end
   end
 end

--- a/app/models/activities/delete_records.rb
+++ b/app/models/activities/delete_records.rb
@@ -4,22 +4,6 @@ module Activities
 
     def data_config_type = "record_type"
 
-    def requires_batch_config?
-      true
-    end
-
-    def requires_config_fields?
-      false
-    end
-
-    def requires_files?
-      true
-    end
-
-    def requires_single_file?
-      true
-    end
-
     def select_attributes
       # TODO: [:record_matchpoint]
       []
@@ -32,6 +16,18 @@ module Activities
 
     def self.display_name
       "Delete Records"
+    end
+
+    def self.file_requirement
+      :required_single
+    end
+
+    def self.has_batch_config?
+      true
+    end
+
+    def self.has_config_fields?
+      false
     end
   end
 end

--- a/app/models/activities/export_record_ids.rb
+++ b/app/models/activities/export_record_ids.rb
@@ -4,28 +4,24 @@ module Activities
 
     def data_config_type = "record_type"
 
-    def requires_batch_config?
-      false
-    end
-
-    def requires_config_fields?
-      true
-    end
-
-    def requires_files?
-      false
-    end
-
-    def requires_single_file?
-      false
-    end
-
     def workflow
       []
     end
 
     def self.display_name
       "Export Record IDs"
+    end
+
+    def self.file_requirement
+      :none
+    end
+
+    def self.has_batch_config?
+      false
+    end
+
+    def self.has_config_fields?
+      true
     end
   end
 end

--- a/app/models/activities/import_terms.rb
+++ b/app/models/activities/import_terms.rb
@@ -4,28 +4,24 @@ module Activities
 
     def data_config_type = "term_list"
 
-    def requires_batch_config?
-      false
-    end
-
-    def requires_config_fields?
-      false
-    end
-
-    def requires_files?
-      true
-    end
-
-    def requires_single_file?
-      true
-    end
-
     def workflow
       []
     end
 
     def self.display_name
       "Import Terms"
+    end
+
+    def self.file_requirement
+      :required_single
+    end
+
+    def self.has_batch_config?
+      false
+    end
+
+    def self.has_config_fields?
+      false
     end
   end
 end

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -9,7 +9,7 @@ class Activity < ApplicationRecord
   has_one :batch_config, dependent: :destroy
   accepts_nested_attributes_for :batch_config
 
-  validates :batch_config, presence: true, if: -> { requires_batch_config? }
+  validates :batch_config, presence: true, if: -> { self.class.has_batch_config? }
   validate :data_config, :is_eligible?
 
   with_options presence: true do
@@ -41,23 +41,6 @@ class Activity < ApplicationRecord
     tasks.where(status: "pending").order(:created_at).first
   end
 
-  # TODO: these are really all class methods
-  def requires_batch_config?
-    raise NotImplementedError
-  end
-
-  def requires_config_fields?
-    raise NotImplementedError
-  end
-
-  def requires_files?
-    raise NotImplementedError
-  end
-
-  def requires_single_file?
-    raise NotImplementedError
-  end
-
   def select_attributes
     BatchConfig.select_attributes
   end
@@ -84,6 +67,24 @@ class Activity < ApplicationRecord
 
   def self.display_name
     raise NotImplementedError
+  end
+
+  # Subclasses should implement one of:
+  # :none, :required_single, :required_multiple, :optional_multiple
+  def self.file_requirement
+    raise NotImplementedError
+  end
+
+  def self.has_batch_config?
+    raise NotImplementedError
+  end
+
+  def self.has_config_fields?
+    raise NotImplementedError
+  end
+
+  def self.requires_files?
+    [:required_single, :required_multiple].include?(file_requirement)
   end
 
   private

--- a/app/views/activities/_form.html.erb
+++ b/app/views/activities/_form.html.erb
@@ -43,11 +43,11 @@
                                        class: "select select-bordered w-full" %>
           </div>
 
-          <% if activity.requires_files? %>
-            <%= form.label :files, activity.requires_single_file? ? "File" : "Files", class: "label-text font-medium" %>
+          <% if activity.class.file_requirement != :none %>
+            <%= form.label :files, activity.class.file_requirement == :required_single ? "File" : "Files", class: "label-text font-medium" %>
             <div class="sm:col-span-3">
               <%= form.file_field :files,
-                                  multiple: !activity.requires_single_file?,
+                                  multiple: activity.class.file_requirement != :required_single,
                                   name: "activity[files][]",
                                   class: "file-input file-input-bordered w-full" %>
             </div>
@@ -55,11 +55,11 @@
         </div>
       </div>
 
-      <% if activity.requires_config_fields? %>
+      <% if activity.class.has_config_fields? %>
         <%= render "#{activity.class.display_name.parameterize(separator: "_")}_fields", form: form, activity: activity %>
       <% end %>
 
-      <% if activity.requires_batch_config? %>
+      <% if activity.class.has_batch_config? %>
         <div class="mb-6">
           <h3 class="text-base-content/70 font-semibold border-b border-base-400 pb-2 mb-4">Batch config</h3>
 

--- a/test/controllers/tasks_controller_access_test.rb
+++ b/test/controllers/tasks_controller_access_test.rb
@@ -11,13 +11,22 @@ class TasksControllerAccessTest < ActionDispatch::IntegrationTest
     sign_in(@admin)
 
     @admin_activity = create_activity(
-      type: "Activities::CheckMediaDerivatives", user: @admin, data_config: @data_config
+      type: "Activities::CheckMediaDerivatives",
+      user: @admin,
+      data_config: @data_config,
+      files: create_uploaded_files(["test.csv"])
     )
     @reader_activity = create_activity(
-      type: "Activities::CheckMediaDerivatives", user: @reader, data_config: @data_config
+      type: "Activities::CheckMediaDerivatives",
+      user: @reader,
+      data_config: @data_config,
+      files: create_uploaded_files(["test.csv"])
     )
     @external_activity = create_activity(
-      type: "Activities::CheckMediaDerivatives", user: @external_user, data_config: @data_config
+      type: "Activities::CheckMediaDerivatives",
+      user: @external_user,
+      data_config: @data_config,
+      files: create_uploaded_files(["test.csv"])
     )
 
     @admin_task = @admin_activity.tasks.first

--- a/test/helpers/factory_helpers.rb
+++ b/test/helpers/factory_helpers.rb
@@ -19,7 +19,7 @@ module FactoryHelpers
     attributes[:data_config] = create_data_config_record_type unless attributes[:data_config]
     activity = Activity.new(attributes)
 
-    if activity.requires_batch_config? && !activity.batch_config
+    if activity.class.has_batch_config? && !activity.batch_config
       activity.build_batch_config
     end
 


### PR DESCRIPTION
This just follows through on the TODO to make the
requires methods be class methods. Also they are
renamed to be a bit clearer, and files now use
symbols to differentiate requirements for the ui.
