### PR TITLE
Cleaner perform_with for check media service

### DIFF
--- a/app/jobs/process_media_derivatives_action_job.rb
+++ b/app/jobs/process_media_derivatives_action_job.rb
@@ -18,7 +18,7 @@ class ProcessMediaDerivativesActionJob < ApplicationJob
       handler.client, type: type, field: field, value: identifier
     )
 
-    service.perform_with!(action)
+    action.done!(service.perform_with(action))
   rescue => e
     feedback = action.feedback_for
     feedback.add_to_errors(subtype: :application_error, details: e)

--- a/app/services/collection_space/check_media_service.rb
+++ b/app/services/collection_space/check_media_service.rb
@@ -36,26 +36,26 @@ module CollectionSpace
       blob.csid && blob.derivatives_count.to_i == EXPECTED_DERIVABLE_COUNT
     end
 
-    def perform_with!(action)
+    def perform_with(action)
       feedback = action.feedback_for
 
       begin
         retrieve_data
       rescue => e
         feedback.add_to_errors(subtype: :request_error, details: "#{name} - #{e.message}")
-        action.done!(feedback) && return
+        return feedback
       end
 
       unless is_derivable?
-        action.done! && return
+        return feedback
       end
 
       unless verify?
         feedback.add_to_errors(subtype: :derivative_count_mismatch, details: blob)
-        action.done!(feedback) && return
+        return feedback
       end
 
-      action.done!
+      feedback
     end
 
     def retrieve_data

--- a/test/services/collection_space/check_media_service_test.rb
+++ b/test/services/collection_space/check_media_service_test.rb
@@ -139,60 +139,50 @@ module CollectionSpace
       end
     end
 
-    # perform_with! tests
-    test "perform_with! completes action when all derivatives present" do
+    # perform_with tests
+    test "perform_with returns feedback when all derivatives present" do
       action = create_action_for_service_test
 
       @service.stub :retrieve_data, set_blob(csid: "b1", mime_type: "image/jpeg", derivatives_count: 5) do
-        @service.perform_with!(action)
+        feedback = @service.perform_with(action)
+        assert feedback.ok?
       end
-
-      assert action.reload.progress_completed?
-      assert_nil action.feedback
     end
 
-    test "perform_with! completes action without feedback when not derivable" do
+    test "perform_with returns feedback without errors when not derivable" do
       action = create_action_for_service_test
 
       @service.stub :retrieve_data, set_blob(csid: "b1", mime_type: "application/pdf") do
-        @service.perform_with!(action)
+        feedback = @service.perform_with(action)
+        assert feedback.ok?
       end
-
-      assert action.reload.progress_completed?
-      assert_nil action.feedback
     end
 
-    test "perform_with! completes action without feedback when no blob csid" do
+    test "perform_with returns feedback without errors when no blob csid" do
       action = create_action_for_service_test
 
       @service.stub :retrieve_data, nil do
-        @service.perform_with!(action)
+        feedback = @service.perform_with(action)
+        assert feedback.ok?
       end
-
-      assert action.reload.progress_completed?
-      assert_nil action.feedback
     end
 
-    test "perform_with! records derivative_count_mismatch when verify fails" do
+    test "perform_with returns feedback with derivative_count_mismatch when verify fails" do
       action = create_action_for_service_test
 
       @service.stub :retrieve_data, set_blob(csid: "b1", mime_type: "image/jpeg", derivatives_count: 3) do
-        @service.perform_with!(action)
+        feedback = @service.perform_with(action)
+        refute feedback.ok?
       end
-
-      assert action.reload.progress_completed?
-      refute action.feedback_for.ok?
     end
 
-    test "perform_with! records request_error when retrieve_data raises" do
+    test "perform_with returns feedback with request_error when retrieve_data raises" do
       action = create_action_for_service_test
 
       @service.stub :retrieve_data, -> { raise "Connection refused" } do
-        @service.perform_with!(action)
+        feedback = @service.perform_with(action)
+        refute feedback.ok?
       end
-
-      assert action.reload.progress_completed?
-      refute action.feedback_for.ok?
     end
 
     private


### PR DESCRIPTION
Only handle feedback, let the job resolve the action. This means the
service doesn't know too much about the action, while keeping the job
mostly behavior free. Testing all round is easier.
