### PR TITLE
Replace auto-trigger with run first task

### DIFF
--- a/app/models/concerns/task_definition.rb
+++ b/app/models/concerns/task_definition.rb
@@ -13,12 +13,11 @@ module TaskDefinition
     end
 
     attr_reader :name, :dependencies
-    attribute :display_name, :handler, :action_handler, :finalizer, :auto_trigger
+    attribute :display_name, :handler, :action_handler, :finalizer
 
     def initialize(name)
       @name = name
       @dependencies = []
-      @auto_trigger = false
     end
 
     def depends_on(*task_types)

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -62,7 +62,6 @@ class Task < ApplicationRecord
   task_type :process_uploaded_files do
     display_name "Process Uploaded Files"
     handler ProcessUploadedFilesJob
-    auto_trigger true
   end
 
   task_type :pre_check_ingest_data do

--- a/app/services/workflow_manager.rb
+++ b/app/services/workflow_manager.rb
@@ -96,12 +96,11 @@ class WorkflowManager
 
   ##### Activity entry points
 
-  # Called from Activity#after_create_commit. Starts every task whose type
-  # was defined with `auto_trigger true`.
+  # Called from Activity#after_create_commit. Starts the first task.
   def self.start_workflow(activity)
-    activity.tasks.reload.each do |task|
-      run_task(task) if task.task_config&.auto_trigger
-    end
+    first_task_type = activity.workflow.first
+    first_task = activity.tasks.find_by(type: first_task_type.to_s) if first_task_type
+    run_task(first_task) if first_task
     activity.tasks.reset
   end
 

--- a/test/models/activity_test.rb
+++ b/test/models/activity_test.rb
@@ -211,7 +211,7 @@ class ActivityTest < ActiveSupport::TestCase
     activity.destroy
   end
 
-  test "auto-trigger task transitions to queued after activity creation" do
+  test "first task transitions to queued after activity creation" do
     activity = create_activity(
       type: :create_or_update_records,
       config: {action: "create"},
@@ -219,8 +219,8 @@ class ActivityTest < ActiveSupport::TestCase
       files: create_uploaded_files(["test.csv"])
     )
 
-    auto_trigger_task = activity.tasks.find_by(type: "process_uploaded_files")
-    assert_equal Task::QUEUED, auto_trigger_task.progress_status
+    first_task = activity.tasks.find_by(type: "process_uploaded_files")
+    assert_equal Task::QUEUED, first_task.progress_status
     activity.destroy
   end
 
@@ -244,7 +244,7 @@ class ActivityTest < ActiveSupport::TestCase
     end
   end
 
-  test "auto-trigger sees all sibling tasks during execution" do
+  test "sees all sibling tasks during execution" do
     activity = create_activity(
       type: :create_or_update_records,
       config: {action: "create"},
@@ -252,11 +252,11 @@ class ActivityTest < ActiveSupport::TestCase
       files: create_uploaded_files(["test.csv"])
     )
 
-    auto_trigger_task = activity.tasks.find_by(type: "process_uploaded_files")
+    first_task = activity.tasks.find_by(type: "process_uploaded_files")
     sibling_task = activity.tasks.find_by(type: "pre_check_ingest_data")
 
-    assert_equal Task::QUEUED, auto_trigger_task.progress_status
-    assert_not_nil sibling_task, "Sibling task should exist when auto-trigger fires"
+    assert_equal Task::QUEUED, first_task.progress_status
+    assert_not_nil sibling_task, "Sibling task should exist when first task fires"
     activity.destroy
   end
 

--- a/test/models/task_test.rb
+++ b/test/models/task_test.rb
@@ -1,3 +1,4 @@
+require "test_helper"
 require "minitest/mock"
 
 class TaskTest < ActiveSupport::TestCase
@@ -361,7 +362,7 @@ class TaskTest < ActiveSupport::TestCase
       files: create_uploaded_files(["test.csv"])
     )
 
-    # Reload to re-establish inverse association cleared by with_lock during auto-trigger
+    # Reload to re-establish inverse association cleared by with_lock
     first_task = activity.tasks.reload.first
     mock_finalizer = Minitest::Mock.new
     mock_finalizer.expect :perform_later, nil, [first_task]
@@ -608,6 +609,19 @@ class TaskTest < ActiveSupport::TestCase
 
     assert_nil WorkflowManager.run_task(@task)
     assert_equal Task::RUNNING, @task.reload.progress_status
+  end
+
+  test "run_task is a no-op when task is already completed" do
+    @task.save!
+    @task.update!(
+      progress_status: Task::COMPLETED,
+      outcome_status: Task::SUCCEEDED,
+      started_at: Time.current,
+      completed_at: Time.current
+    )
+
+    assert_nil WorkflowManager.run_task(@task)
+    assert @task.reload.progress_completed?
   end
 
   test "run_task is a no-op when dependencies have not succeeded" do

--- a/test/services/workflow_manager_test.rb
+++ b/test/services/workflow_manager_test.rb
@@ -47,6 +47,71 @@ class WorkflowManagerTest < ActiveSupport::TestCase
     assert_equal 1, @task.reload.actions_completed_count
   end
 
+  test "start_workflow runs first workflow task" do
+    activity = create_activity(
+      type: :create_or_update_records,
+      config: {action: "create"},
+      data_config: create_data_config_record_type(record_type: "start_workflow_records"),
+      files: create_uploaded_files(["test.csv"])
+    )
+
+    first_task = activity.tasks.find_by(type: "process_uploaded_files")
+
+    WorkflowManager.expects(:run_task).with(first_task).once
+
+    WorkflowManager.start_workflow(activity)
+  end
+
+  test "start_workflow does nothing when workflow has no tasks" do
+    activity = create_activity(
+      type: :export_record_ids,
+      data_config: create_data_config_record_type(record_type: "empty_workflow_records")
+    )
+
+    WorkflowManager.expects(:run_task).never
+
+    WorkflowManager.start_workflow(activity)
+  end
+
+  test "start_workflow is a no-op when first task has already started" do
+    activity = create_activity(
+      type: :create_or_update_records,
+      config: {action: "create"},
+      data_config: create_data_config_record_type(record_type: "already_started_workflow_records"),
+      files: create_uploaded_files(["test.csv"])
+    )
+    first_task = activity.tasks.find_by(type: "process_uploaded_files")
+
+    assert_equal Task::QUEUED, first_task.progress_status
+    ProcessUploadedFilesJob.expects(:perform_later).never
+
+    WorkflowManager.start_workflow(activity)
+
+    assert_equal Task::QUEUED, first_task.reload.progress_status
+  end
+
+  test "start_workflow is a no-op when first task has already completed" do
+    activity = create_activity(
+      type: :create_or_update_records,
+      config: {action: "create"},
+      data_config: create_data_config_record_type(record_type: "completed_workflow_records"),
+      files: create_uploaded_files(["test.csv"])
+    )
+    first_task = activity.tasks.find_by(type: "process_uploaded_files")
+    first_task.update!(
+      progress_status: Task::COMPLETED,
+      outcome_status: Task::SUCCEEDED,
+      started_at: Time.current,
+      completed_at: Time.current
+    )
+
+    ProcessUploadedFilesJob.expects(:perform_later).never
+
+    WorkflowManager.start_workflow(activity)
+
+    assert first_task.reload.progress_completed?
+  end
+
   test "complete_task only advances activity on first completion" do
     finalizer_calls = 0
     finalizer = Object.new


### PR DESCRIPTION
Rather than have a dedicated property for auto trigger, simply
have start_workflow run the first workflow task.
